### PR TITLE
Add zoroscopo as a side project

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -68,6 +68,12 @@
         "name": "converter.gege.codes",
         "description": "Transform your images between JPG, PNG, and AVIF formats with our lightning-fast, secure converter. No uploads required - everything happens in your browser.",
         "link": "https://converter.gege.codes/"
+      },
+      "zoroscopo": {
+        "name": "Zoroscopo",
+        "description": "A modern and intuitive horoscope application that provides daily astrological insights and predictions. Built with cutting-edge web technologies, it offers personalized readings based on zodiac signs with a beautiful, responsive interface.",
+        "link": "https://zoroscopo.vercel.app/",
+        "github": "https://github.com/iltonandrew/zoroscopo"
       }
     }
   },

--- a/locales/pt-BR/common.json
+++ b/locales/pt-BR/common.json
@@ -68,6 +68,12 @@
         "name": "converter.gege.codes",
         "description": "Transforme suas imagens entre JPG, PNG e AVIF com nosso conversor ultrarrápido e seguro. Sem uploads — tudo acontece no seu navegador.",
         "link": "https://converter.gege.codes/"
+      },
+      "zoroscopo": {
+        "name": "Zoroscopo",
+        "description": "Uma aplicação de horóscopo moderna e intuitiva que oferece insights astrológicos e previsões diárias. Construída com tecnologias web de ponta, proporciona leituras personalizadas baseadas em signos do zodíaco com uma interface bonita e responsiva.",
+        "link": "https://zoroscopo.vercel.app/",
+        "github": "https://github.com/iltonandrew/zoroscopo"
       }
     }
   },

--- a/public/images/companies/zoroscopo.svg
+++ b/public/images/companies/zoroscopo.svg
@@ -1,0 +1,10 @@
+<svg width="84" height="84" viewBox="0 0 84 84" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="84" height="84" rx="12" fill="#6366F1"/>
+  <circle cx="42" cy="42" r="32" fill="white" opacity="0.1"/>
+  <circle cx="42" cy="42" r="24" fill="white" opacity="0.2"/>
+  <circle cx="42" cy="42" r="16" fill="white" opacity="0.3"/>
+  <circle cx="42" cy="42" r="8" fill="white"/>
+  <path d="M42 8L48 20L60 26L48 32L42 44L36 32L24 26L36 20L42 8Z" fill="white" opacity="0.8"/>
+  <path d="M42 44L48 56L60 62L48 68L42 80L36 68L24 62L36 56L42 44Z" fill="white" opacity="0.6"/>
+  <circle cx="42" cy="42" r="2" fill="#6366F1"/>
+</svg>

--- a/src/components/Companies/CompanyListItem.tsx
+++ b/src/components/Companies/CompanyListItem.tsx
@@ -20,6 +20,7 @@ type CompanyProps = {
   description: string;
   stack: string;
   link?: string;
+  github?: string;
 };
 
 export default function Company({
@@ -30,6 +31,7 @@ export default function Company({
   description,
   stack,
   link,
+  github,
 }: CompanyProps) {
   const { t } = useTranslation();
   const ref = useRef<HTMLDivElement | null>(null);
@@ -84,23 +86,36 @@ export default function Company({
           </Box>
         )}
         <Stack direction="column" pl={4}>
-          {link ? (
-            <Link href={link} isExternal>
-              <Text
-                fontWeight={"bold"}
-                fontSize="xl"
-                marginBottom={"-2"}
-                color="brand.primary"
-                _hover={{ textDecoration: "underline" }}
-              >
+          <Stack direction="row" align="center" spacing={2}>
+            {link ? (
+              <Link href={link} isExternal>
+                <Text
+                  fontWeight={"bold"}
+                  fontSize="xl"
+                  marginBottom={"-2"}
+                  color="brand.primary"
+                  _hover={{ textDecoration: "underline" }}
+                >
+                  {name}
+                </Text>
+              </Link>
+            ) : (
+              <Text fontWeight={"bold"} fontSize="xl" marginBottom={"-2"}>
                 {name}
               </Text>
-            </Link>
-          ) : (
-            <Text fontWeight={"bold"} fontSize="xl" marginBottom={"-2"}>
-              {name}
-            </Text>
-          )}
+            )}
+            {github && (
+              <Link href={github} isExternal>
+                <Text
+                  fontSize="sm"
+                  color="gray.500"
+                  _hover={{ color: "brand.primary", textDecoration: "underline" }}
+                >
+                  GitHub
+                </Text>
+              </Link>
+            )}
+          </Stack>
           <Text>{role}</Text>
           <Text fontStyle={"italic"} fontSize={"2xs"}>
             {data}

--- a/src/components/Companies/index.tsx
+++ b/src/components/Companies/index.tsx
@@ -82,6 +82,17 @@ export default function Companies() {
           stack="NextJS, TypeScript, Tailwind CSS"
           link={t("work.sideProjects.converter.link")}
         />
+        <Divider />
+        <CompanyListItem
+          name={t("work.sideProjects.zoroscopo.name")}
+          role={t("work.sideProjects.personalProject")}
+          data="2025"
+          image="zoroscopo.svg"
+          description={t("work.sideProjects.zoroscopo.description")}
+          stack="NextJS, TypeScript, Tailwind CSS, Vercel"
+          link={t("work.sideProjects.zoroscopo.link")}
+          github={t("work.sideProjects.zoroscopo.github")}
+        />
       </Stack>
 
       <DownloadButton />


### PR DESCRIPTION
Add Zoroscopo to the side projects section with bilingual descriptions and a dedicated GitHub link.

The `CompanyListItem` component was updated to support a separate GitHub link, allowing both the live project and its repository to be displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-16d57309-282b-46bd-b9db-355da46c49de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-16d57309-282b-46bd-b9db-355da46c49de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

